### PR TITLE
Suporte para relacionar la misma tabla varias veces con diferentes alias

### DIFF
--- a/ukupacha/Graph.py
+++ b/ukupacha/Graph.py
@@ -11,6 +11,8 @@ import json
 import sys
 
 
+
+
 class UkuPachaGraph:
     """
     Class to perform the relations in the database across mutiples tables, databases or table spaces.
@@ -45,12 +47,14 @@ class UkuPachaGraph:
                 ndata.append({"table": main_table, "data": [data_row]})
 
             for table_dict in tables:
-                table = list(table_dict.keys())[0]
+                table_full = list(table_dict.keys())[0]
+                table = table_full.split("/")[0]
+
                 if debug:
                     print(f"table = {table}")
                     print(list(table_dict.keys()))
-                if table_dict[table] is not None:
-                    for table_relations in table_dict[table]:
+                if table_dict[table_full] is not None:
+                    for table_relations in table_dict[table_full]:
                         db = table_relations["DB"]
                         keys = {}
                         for key in table_relations["KEYS"]:
@@ -85,7 +89,8 @@ class UkuPachaGraph:
                         if debug:
                             print(f"len subtables = {len(sub_tables_dict)}")
                         for sub_table_dict in sub_tables_dict:
-                            sub_table = list(sub_table_dict.keys())[0]
+                            sub_table_full = list(sub_table_dict.keys())[0]
+                            sub_table=sub_table_full.split("/")[0]
                             if debug:
                                 print(f"sub_table = {sub_table}")
 
@@ -99,7 +104,7 @@ class UkuPachaGraph:
                                     # sub_table_data.append({"table":sub_table,"data":req_data})
                                     sub_table_data.append(req_data)
                                 ndata.append(
-                                    {"table": sub_table, "data": sub_table_data, "keys": keys})
+                                    {"table": sub_table_full, "data": sub_table_data, "keys": keys})
 
                             except:
                                 if debug:


### PR DESCRIPTION
Este es un caso de uso complejo que me resulto del análisis en la extracción de patentes en la tabla
EN_PATENTE de Scienti.
resulta que la tabla EN_PATENTE se relaciona varias veces con la tabla EN_INSTITUCION usandon diferentes ids que se 
encuentran en la tabla EN_PATENTE, pero yo no puedo meter todas las instituciones de esta relación en un solo campo "institution" en el json que se genera, por que son conceptualmente diferentes
![image](https://user-images.githubusercontent.com/275148/189457864-0527f176-f2f8-48af-a2aa-b7d004c95e85.png)

para esto me tocó diseñar un sistema de alias, que se le ponen a la tabla con un separador para indicar que esta table es de otro campo conceptualmente diferente en el json de salida, para eso se pone una expresión regular "/"  con una etiqueta.

![image](https://user-images.githubusercontent.com/275148/189458347-aafed404-754f-4884-ba75-bc27f910a0ca.png)

en el diccionario de relaciones se ve así:
![image](https://user-images.githubusercontent.com/275148/189458421-578af207-0ec0-4461-8397-d57f78978f29.png)

y en el campo de la lista de alias para el JSON así:
![image](https://user-images.githubusercontent.com/275148/189458484-46ff9933-ea1e-44b5-87c8-f1a6199f02dc.png)



**De esta forma cuando se hace el parsing de los campos para generar el json, el sistema sabe que se debe crear una entrada diferente para la tabla EN_INSTITUCION.**
